### PR TITLE
Prepare for Matomo 6

### DIFF
--- a/ClassicFontTheme.php
+++ b/ClassicFontTheme.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\ClassicFontTheme;
+
+use Piwik\Plugin;
+
+class ClassicFontTheme extends Plugin
+{
+    public function registerEvents()
+    {
+        return [
+            'Theme.configureThemeVariables' => 'configureThemeVariables',
+        ];
+    }
+
+    public function configureThemeVariables(Plugin\ThemeStyles $vars): void
+    {
+        $vars->fontFamilyBase = 'Arial, sans-serif, Verdana';
+    }
+}

--- a/plugin.json
+++ b/plugin.json
@@ -1,14 +1,14 @@
 {
     "name": "ClassicFontTheme",
     "description": "Piwik Platform showcase: example of how to create a simple Theme.",
-    "version": "5.0.0",
+    "version": "6.0.0",
     "theme": true,
     "stylesheet": "stylesheets/theme.less",
     "homepage": "https://piwik.org",
     "license": "GPL v3+",
     "keywords": ["font", "theme", "arial", "verdana"],
     "require": {
-        "matomo": ">=5.0.0-b1,<6.0.0-b1"
+        "matomo": ">=6.0.0-b1,<7.0.0-b1"
     },
     "support": {
         "email": "hello@piwik.org",

--- a/stylesheets/theme.less
+++ b/stylesheets/theme.less
@@ -1,1 +1,2 @@
-@theme-fontFamily-base: Arial, sans-serif, Verdana;
+// The base font family is set through Theme.configureThemeVariables, since the theme
+// variables are emitted as CSS custom properties that switch at runtime.


### PR DESCRIPTION
## Description

Matomo 6 compatibility for ClassicFontTheme. **The theme's one job stopped working in Matomo 6**, so this is more than a metadata bump.

The whole theme was a single Less override, `@theme-fontFamily-base: Arial, sans-serif, Verdana`. Matomo 6 emits theme variables as CSS custom properties instead: `ThemeStyles::toLessCode()` generates `@theme-fontFamily-base: ~"var(--theme-fontFamily-base)"` and prepends it to the merged stylesheet, so a theme redefining that variable in its own Less no longer reaches anything.

Verified against a Matomo 6 instance with this theme **selected as the active theme**: `--theme-fontFamily-base` still resolved to core's default `-apple-system, BlinkMacSystemFont, …` stack, and the entire merged CSS differed from the unthemed build by 30 bytes. After the change it resolves to `Arial, sans-serif, Verdana`.

### What changed
- **`plugin.json`** — version `5.0.0` &rarr; `6.0.0`, `require.matomo` &rarr; `>=6.0.0-b1,<7.0.0-b1`.
- **New `ClassicFontTheme.php`** — registers `Theme.configureThemeVariables` and sets `$vars->fontFamilyBase`, which is how core's own `ExampleTheme` does it. The font list is carried over unchanged.
- **`stylesheets/theme.less`** — the dead override replaced with a note pointing at the new home. The stylesheet stays declared in `plugin.json`, matching ExampleTheme's layout.

### Worth a look
The font list is preserved **exactly** as it was: `Arial, sans-serif, Verdana`. Note that the generic `sans-serif` sits before `Verdana`, so Verdana can never be reached — that looks like a long-standing bug, but fixing it would change what the theme renders, so I left it alone. Say the word if it should become `Arial, Verdana, sans-serif` (what ExampleTheme uses).

Nothing else applied: the repo has no `composer.json`, `CHANGELOG.md`, `Updates/`, `vue/src`, `phpstan.neon`, `phpcs.xml`, tests, or test workflow.

Both commits are `[ignore_release]` — this adapts to a moved API rather than changing what the theme does, and nothing is releasable for Matomo 6 until core ships.

## Issue No

Related to the Matomo 6 plugin preparation effort.

## Steps to Replicate the Issue

1. Mount the plugin into a Matomo 6 checkout and `./console plugin:activate ClassicFontTheme`.
2. Set `[General] default_theme = ClassicFontTheme` and clear caches.
3. Request `index.php?module=Proxy&action=getCss` &mdash; `--theme-fontFamily-base` is now `Arial, sans-serif, Verdana`; before this change it was core's default stack.
4. `./console core:update` reports no pending migrations, and phpcs is clean on the new class.

## Checklist
- [✔] Tested locally or on demo2/demo3?
- [NA] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [✔] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
